### PR TITLE
Added translations for the saleskin/flarum-auth-google library.

### DIFF
--- a/locale/saleskin-flarum-auth-google.yml
+++ b/locale/saleskin-flarum-auth-google.yml
@@ -1,0 +1,21 @@
+saleksin-auth-google:
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
+  # Translations in this namespace are used by the admin interface.
+  admin:
+
+    # These translations are used in the Google Settings modal dialog.
+    google_settings:
+      client_id_label: App ID
+      client_secret_label: App Secret
+      title: Google Instellingen
+
+  # Translations in this namespace are used by the forum user interface.
+  forum:
+
+    # These translations are used in the Log In modal dialog.
+    log_in:
+      with_google_button: Log in met Google


### PR DESCRIPTION
I added some additional dutch translations for the saleskin/flarum-auth-google library I am currently using to provide Google logins, to make it match the texts that have been previously translated for the Facebook login button.