### PR TITLE
Duplicate key

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -458,10 +458,6 @@ core:
       three_text: "{first}, {second}, en {third}"
       two_text: "{first} en {second}"
 
-    # These translations are used to modify usernames.
-    username:
-      deleted_text: "[verwijderd]"
-
   # Translations in this namespace are used in views other than Flarum's normal JS client.
   views:
 


### PR DESCRIPTION
Next Symfony\Component\Translation\Exception\InvalidResourceException: The file "vendor/composer/../michaelbelgium/flarum-dutch/locale/core.yml" does not contain valid YAML: Duplicate key "username" detected at line 465 (near "# Translations in this namespace are used in views other than Flarum